### PR TITLE
Add Community Framework 2.1 compatibility

### DIFF
--- a/file/lib/system/event/listener/UserNotificationNodePushListener.class.php
+++ b/file/lib/system/event/listener/UserNotificationNodePushListener.class.php
@@ -17,7 +17,7 @@ class UserNotificationNodePushListener implements IEventListener {
 	 * @see	\wcf\system\event\IEventListener::execute()
 	 */
 	public function execute($eventObj, $className, $eventName) {
-		if ($eventObj->getActionName() !== 'addRecipients') return;
+		if ($eventObj->getActionName() !== 'addRecipients' && $eventObj->getActionName() !== 'createStackable' && $eventObj->getActionName() !== 'createDefault') return;
 		
 		$parameters = $eventObj->getParameters();
 		


### PR DESCRIPTION
With version 2.1 the `addRecipients` action was removed, so the new `createStackable` and `createDefault` action needs also to be observed.
